### PR TITLE
Fix CA url for staging environment

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -8,7 +8,7 @@ IFS=$'\n\t'
 use_staging_ca=${USE_STAGING_CA:-}
 
 if [[ "$use_staging_ca" == "true" ]]; then
-  use_staging_ca="-ca \"https://acme-staging.api.letsencrypt.org/directory\""
+  use_staging_ca="-ca \"https://acme-staging-v02.api.letsencrypt.org/directory\""
 else
   use_staging_ca=""
 fi


### PR DESCRIPTION
I've been trying to set up a OSeM installation for development purposes, and using the Let's Encrypt Staging environment for that.

When trying to start up this container, I would get the following error message
```
2018-10-16T21:37:57Z ff1c5ffdcb12 /usr/bin/confd[13]: INFO Backend set to env
2018-10-16T21:37:57Z ff1c5ffdcb12 /usr/bin/confd[13]: INFO Starting confd
2018-10-16T21:37:57Z ff1c5ffdcb12 /usr/bin/confd[13]: INFO Backend nodes set to
2018-10-16T21:37:57Z ff1c5ffdcb12 /usr/bin/confd[13]: INFO Target config /etc/caddy/vhosts/additional.enabled out of sync
2018-10-16T21:37:57Z ff1c5ffdcb12 /usr/bin/confd[13]: INFO Target config /etc/caddy/vhosts/additional.enabled has been updated
Activating privacy features... 2018/10/16 21:37:57 directory missing new registration URL
```

After that, run.sh would exit, and the container would try to restart a few seconds later, only to run into the same error again.

A quick Google search revealed that this was likely due to the wrong URL being used for the staging environment. See https://github.com/mholt/caddy/issues/1755#issuecomment-385179486 for reference.

With this fix, the container starts up fine now.