### PR TITLE
Set tls versions

### DIFF
--- a/vhosts/0static-hosts.enabled
+++ b/vhosts/0static-hosts.enabled
@@ -51,6 +51,9 @@
 }
 
 http://internet-test.{$WEB_DOMAIN}, https://internet-test.{$WEB_DOMAIN} {
+  tls {$ISSUER_ADDRESS} {
+    protocols tls1.0 tls 1.2
+  }
   root /etc/caddy/roots/internet-test
   on startup mkdir -p /etc/caddy/roots/internet-test
   on startup "sh -c \"echo 'Connection successful! / Verbindung erfolgreich!' > /etc/caddy/roots/internet-test/index.txt\""

--- a/vhosts/0static-hosts.enabled
+++ b/vhosts/0static-hosts.enabled
@@ -52,7 +52,7 @@
 
 http://internet-test.{$WEB_DOMAIN}, https://internet-test.{$WEB_DOMAIN} {
   tls {$ISSUER_ADDRESS} {
-    protocols tls1.0 tls 1.2
+    protocols tls1.0 tls1.2
   }
   root /etc/caddy/roots/internet-test
   on startup mkdir -p /etc/caddy/roots/internet-test

--- a/vhosts/1api.enabled
+++ b/vhosts/1api.enabled
@@ -1,4 +1,7 @@
 {$API_DOMAIN} {
+  tls {$ISSUER_ADDRESS} {
+    protocols tls1.0 tls1.2
+  }
   gzip
 
   # some security headers
@@ -18,6 +21,9 @@
 }
 
 {$INGRESS_DOMAIN} {
+  tls {$ISSUER_ADDRESS} {
+    protocols tls1.0 tls1.2
+  }
   gzip
 
   header / {

--- a/vhosts/1api.enabled
+++ b/vhosts/1api.enabled
@@ -1,10 +1,6 @@
 {$API_DOMAIN} {
   gzip
 
-  #rate limits for posting boxes
-  ratelimit post /boxes 3 3 minute
-  ratelimit post /users 20 20 minute
-
   # some security headers
   header / {
     X-XSS-Protection "1; mode=block"

--- a/vhosts/1api.enabled
+++ b/vhosts/1api.enabled
@@ -29,7 +29,7 @@
 
     # Workaround do minimize 502 errors
     # https://github.com/mholt/caddy/issues/1925
-    fail_timeout 0
+    # fail_timeout 0
 
     header_downstream -Server
     header_downstream -Access-Control-Allow-Headers
@@ -63,7 +63,7 @@
 
     # Workaround do minimize 502 errors
     # https://github.com/mholt/caddy/issues/1925
-    fail_timeout 0
+    # fail_timeout 0
 
     header_downstream -Server
     header_downstream -Access-Control-Allow-Headers


### PR DESCRIPTION
Set TLS versions for `ingress` and `api`.
Remove `ratelimits` and disable `502` workaround.