### PR TITLE
Add ratelimits for post on /boxes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 #
 FROM abiosoft/caddy:builder as builder
 
-ARG version="0.11.0"
+ARG version="1.0.1"
 ARG plugins="git,ratelimit"
 
 RUN VERSION=${version} PLUGINS=${plugins} /bin/sh /usr/bin/builder.sh

--- a/vhosts/1api.enabled
+++ b/vhosts/1api.enabled
@@ -6,7 +6,7 @@
   gzip
 
   #rate limits for posting boxes
-  ratelimit post /boxes 6 6 minute
+  ratelimit post /boxes 15 15 minute
 
   # some security headers
   header / {
@@ -30,7 +30,7 @@
   }
 
   #rate limits for posting boxes
-  ratelimit post /boxes 6 6 minute
+  ratelimit post /boxes 15 15 minute
 
   gzip
 
@@ -66,7 +66,7 @@
   gzip
 
   #rate limits for posting boxes
-  ratelimit post /boxes 6 6 minute
+  ratelimit post /boxes 15 15 minute
 
   # strip the headers to a bare minimum to make using the insecure endpoint difficult
   header / {

--- a/vhosts/1api.enabled
+++ b/vhosts/1api.enabled
@@ -2,7 +2,11 @@
   tls {$ISSUER_ADDRESS} {
     protocols tls1.0 tls1.2
   }
+
   gzip
+
+  #rate limits for posting boxes
+  ratelimit post /boxes 6 6 minute
 
   # some security headers
   header / {
@@ -24,6 +28,10 @@
   tls {$ISSUER_ADDRESS} {
     protocols tls1.0 tls1.2
   }
+
+  #rate limits for posting boxes
+  ratelimit post /boxes 6 6 minute
+
   gzip
 
   header / {
@@ -56,6 +64,9 @@
 {$WEB_DOMAIN}:8000, www.{$WEB_DOMAIN}:8000, {$INGRESS_DOMAIN}:80 {
   tls off
   gzip
+
+  #rate limits for posting boxes
+  ratelimit post /boxes 6 6 minute
 
   # strip the headers to a bare minimum to make using the insecure endpoint difficult
   header / {
@@ -98,4 +109,3 @@
   log / stdout "{remote} - [{when_iso}] \"{method} {host}{uri} {proto}\" {status} {size}"
   errors stdout
 }
-


### PR DESCRIPTION
Add ratelimit for `POST /boxes`. Limit is set to 6 request per minute.
Closes #5 